### PR TITLE
bind CrateDB on AWS image to 0.0.0.0

### DIFF
--- a/aws-ami/99_crate.cfg
+++ b/aws-ami/99_crate.cfg
@@ -1,8 +1,10 @@
 # /etc/cloud/cloud.cfg.d/99_crate.cfg
-
+# vim: syntax=yaml
 
 runcmd:
  - '/etc/cloud/cloud.cfg.d/crate-disks.sh'
+ - 'echo "" >> /etc/crate/crate.yml'
+ - 'echo "### CRATE AMI CONFIGURATION ###" >> /etc/crate/crate.yml'
  - 'echo "" >> /etc/crate/crate.yml'
  - 'echo "# use hostname as node name"'
  - 'echo "node.name: $(hostname)" >> /etc/crate/crate.yml'
@@ -13,9 +15,7 @@ runcmd:
  - 'echo "# enable ec2 discovery" >> /etc/crate/crate.yml'
  - 'echo "discovery.type: ec2" >> /etc/crate/crate.yml'
  - 'echo "" >> /etc/crate/crate.yml'
- - 'echo "# Set bind and publish host to _global_" >> /etc/crate/crate.yml'
- - 'echo "network.host: _global_" >> /etc/crate/crate.yml'
+ - 'echo "# bind CrateDB to all network interfaces" >> /etc/crate/crate.yml'
+ - 'echo "network.host: 0.0.0.0" >> /etc/crate/crate.yml'
  - 'chkconfig --levels 3 crate on'
  - 'service crate start'
-
-# vim: syntax=yaml


### PR DESCRIPTION
depending on your configuration, instances may not have public network
interfaces, and may have different interfaces names

as a result, CrateDB would not start if `network.host` is set to
`_globa_` leading to the following exception:

```
[2018-05-02T13:39:02,530][ERROR][o.e.b.BootstrapProxy     ] [ip-10-184-28-117] Exception
java.lang.IllegalArgumentException: No up-and-running global-scope (public) addresses found, got [name:lo (lo), name:eth0 (eth0)]
        at org.elasticsearch.common.network.NetworkUtils.getGlobalAddresses(NetworkUtils.java:204) ~[crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.common.network.NetworkService.resolveInternal(NetworkService.java:252) ~[crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.common.network.NetworkService.resolveInetAddresses(NetworkService.java:220) ~[crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.common.network.NetworkService.resolveBindHostAddresses(NetworkService.java:130) ~[crate-app-2.3.6.jar:2.3.6]
        at io.crate.protocols.postgres.PostgresNetty.resolveBindAddress(PostgresNetty.java:183) ~[crate-app-2.3.6.jar:2.3.6]
        at io.crate.protocols.postgres.PostgresNetty.doStart(PostgresNetty.java:148) ~[crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:69) ~[crate-app-2.3.6.jar:2.3.6]
        at java.util.ArrayList.forEach(ArrayList.java:1257) ~[?:1.8.0_171]
        at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1080) ~[?:1.8.0_171]
        at org.elasticsearch.node.Node.start(Node.java:674) ~[crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.bootstrap.BootstrapProxy.start(BootstrapProxy.java:212) ~[crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.bootstrap.BootstrapProxy.init(BootstrapProxy.java:284) [crate-app-2.3.6.jar:2.3.6]
        at io.crate.bootstrap.CrateDB.init(CrateDB.java:138) [crate-app-2.3.6.jar:2.3.6]
        at io.crate.bootstrap.CrateDB.execute(CrateDB.java:118) [crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:76) [crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:134) [crate-app-2.3.6.jar:2.3.6]
        at org.elasticsearch.cli.Command.main(Command.java:90) [crate-app-2.3.6.jar:2.3.6]
        at io.crate.bootstrap.CrateDB.main(CrateDB.java:87) [crate-app-2.3.6.jar:2.3.6]
        at io.crate.bootstrap.CrateDB.main(CrateDB.java:80) [crate-app-2.3.6.jar:2.3.6]
```