### PR TITLE
use discovery.zen.hosts_provider for EC2 discovery

### DIFF
--- a/aws-ami/99_crate.cfg
+++ b/aws-ami/99_crate.cfg
@@ -13,7 +13,7 @@ runcmd:
  - 'echo "path.data: $(/etc/cloud/cloud.cfg.d/datapaths.sh)" >> /etc/crate/crate.yml'
  - 'echo "" >> /etc/crate/crate.yml'
  - 'echo "# enable ec2 discovery" >> /etc/crate/crate.yml'
- - 'echo "discovery.type: ec2" >> /etc/crate/crate.yml'
+ - 'echo "discovery.zen.hosts_provider: ec2" >> /etc/crate/crate.yml'
  - 'echo "" >> /etc/crate/crate.yml'
  - 'echo "# bind CrateDB to all network interfaces" >> /etc/crate/crate.yml'
  - 'echo "network.host: 0.0.0.0" >> /etc/crate/crate.yml'


### PR DESCRIPTION
`discovery.type` has been removed in 3.0