### PR TITLE
Don't install python-software-properties on Ubuntu 18.04+

### DIFF
--- a/easy/install.sh
+++ b/easy/install.sh
@@ -239,7 +239,10 @@ elif [ $OS = "ubuntu" ]; then
         echo "deb https://cdn.crate.io/downloads/deb/stable/ ${UBUNTU_CODENAME} main" | $OPTSUDO tee -a /etc/apt/sources.list.d/crate.list
         echo "deb-src https://cdn.crate.io/downloads/deb/stable/ ${UBUNTU_CODENAME} main" | $OPTSUDO tee -a /etc/apt/sources.list.d/crate.list
     fi
-    $OPTSUDO apt-get install -y python-software-properties software-properties-common
+    if [ $MAJOR_VERSION -lt "18" ]; then
+        # The last version was in "artful" (17.10)
+        $OPTSUDO apt-get install -y python-software-properties software-properties-common
+    fi
     $OPTSUDO apt-get update
 
     dpkg -s "crate" | grep "installed" && {


### PR DESCRIPTION
This package was last shipped with Ubuntu artful (17.10).

To test this, one can use the following Dockerfile. Before this change
the installation failed:

```dockerfile
FROM ubuntu:18.04
COPY easy/install.sh /install.sh
RUN chmod +x /install.sh && \
    apt-get update && \
    apt-get install -y wget gnupg2 openjdk-8-jdk-headless && \
    /install.sh
```