### PR TITLE
Fixed shellcheck remarks in shell script

### DIFF
--- a/aws-ami/crate-disks.sh
+++ b/aws-ami/crate-disks.sh
@@ -10,26 +10,25 @@ DEVICES=$(curl -s "$API/block-device-mapping/" | grep -v 'ami\|root')
 for NAME in $DEVICES
 do
   DEV=$(curl -s "$API/block-device-mapping/$NAME")
-  IS_FORMATTED=$(file -sL /dev/$DEV | grep "filesystem")
+  IS_FORMATTED=$(file -sL "/dev/$DEV" | grep "filesystem")
 
-  if [ ! -z "$IS_FORMATTED" -a "$IS_FORMATTED" != " " ]; then
+  if [ ! -z "$IS_FORMATTED" ] && [ "$IS_FORMATTED" != " " ]; then
     echo "Device is formatted and ready to mount!"
   else
     echo "Device is not formatted"
     # try to format the device
-    mkfs.ext4 -F /dev/$DEV
+    mkfs.ext4 -F "/dev/$DEV"
   fi
 
   # mount the device
-  mkdir -p /mnt/$DEV
-  mount /dev/$DEV /mnt/$DEV
-  if [ $? -eq 0 ]; then
+  mkdir -p "/mnt/$DEV"
+  if mount "/dev/$DEV" "/mnt/$DEV" ; then
     echo "/dev/$DEV   /mnt/$DEV   auto  defaults,nofail,comment=cratedisks  0 2" >> /etc/fstab
     echo "mount successful!"
   else
     echo "mount failed!"
   fi
 
-  mkdir -p /mnt/$DEV/crate
-  chown -R crate:crate /mnt/$DEV/crate
+  mkdir -p "/mnt/$DEV/crate"
+  chown -R crate:crate "/mnt/$DEV/crate"
 done

--- a/aws-ami/datapaths.sh
+++ b/aws-ami/datapaths.sh
@@ -7,13 +7,13 @@ DATA_PATH=""
 for NAME in $DEVICES
 do
   DEV=$(curl -s "$API/block-device-mapping/$NAME/")
-  MNT=$(df | grep $(readlink -f /dev/$DEV) | sed -e 's/\s\+/ /g' | cut -d" " -f6)
+  MNT=$(df | grep "$(readlink -f "/dev/$DEV")" | sed -e 's/\s\+/ /g' | cut -d" " -f6)
   if [ ! -z "$MNT" ]; then
     DATA_PATH="$DATA_PATH,$MNT/crate"
   fi
 done
 
-if [ -z "$DEVICES" -a "$DEVICES" != " " ]; then
+if [ -z "$DEVICES" ] && [ "$DEVICES" != " " ]; then
   # no device has been found
   mkdir -p /var/lib/crate
   chown -R crate:crate /var/lib/crate


### PR DESCRIPTION
Writing shell scripts is hard and comes with lots of pitfalls, be it globbing,
unwanted code execution, subshell overheads, and whatnot.  Furthermore, since
some of these files are downloaded by individuals and then executed on their
computers we should take special care of those scripts to prevent accidental
behavior. See Steam's accidental removal of all files a user owned.

For Shell scripts there's a linter "Shellcheck" that can help maintain more
secure, and cross-shell scripts: https://www.shellcheck.net/

In this PR I ran shellcheck on the given files and fixed the notes accordingly.

Details explanations on the warnings can be found in https://github.com/koalaman/shellcheck/wiki .