### PR TITLE
Allow quick installer to run on all flavors of Linux

### DIFF
--- a/easy/try.sh
+++ b/easy/try.sh
@@ -84,31 +84,12 @@ function wait_until_running() {
     done
 }
 
-# OS/Distro Detection
-if [ -f /etc/debian_version ]; then
-    OS=Debian
-elif [ -f /etc/redhat-release ]; then
-    # Just mark as RedHat and we'll use Python version detection
-    # to know what to install
-    OS=RedHat
-elif [ -f /etc/lsb-release ]; then
-    # shellcheck disable=SC1091
-    . /etc/lsb-release
-    OS=$DISTRIB_ID
-elif [ -f /etc/os-release ]; then
-    # Arch Linux
-    # shellcheck disable=SC1091
-    . /etc/os-release
-    OS=$ID
-elif [ -f /etc/system-release ]; then
-    OS=Amazon
-else
-    OS=$(uname -s)
-fi
-
+# Architecture and OS detection
 ARCH=$(uname -m)
+OS=$(uname -s)
+
 if [ "$ARCH" = "x86_64" ]; then
-  if [ "$OS" = "Debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "RedHat" ]; then
+  if [ "$OS" = "Linux" ]; then
     PLATFORM="x64_linux"
   elif [ "$OS" = "Darwin" ]; then
     PLATFORM="x64_mac"

--- a/easy/try.sh
+++ b/easy/try.sh
@@ -24,7 +24,7 @@
 #
 ###############################################################################
 #
-# Crate Try script
+# CrateDB quick setup program
 
 set -e
 
@@ -41,7 +41,7 @@ function wait_for_user() {
 }
 
 function prf() {
-    echo -e "$INV$BRN$1$END\\n"
+    echo -e "$INV$BRN$1$END"
 }
 
 function on_error() {
@@ -64,9 +64,8 @@ function pre_start_cmd() {
     # display info about crate admin on non gui systems
     if [[ ! $OS = "Darwin" && ! -n $DISPLAY ]]; then
         [ "$(hostname -d)" ] && HOST=$(hostname -f) || HOST=$(hostname)
-        prf "Crate will get started in foreground. To open crate admin goto
-
-    http://$HOST:4200/admin\\n"
+        prf "- CrateDB will be started in the foreground\\n"
+        prf "To open the CrateDB Admin UI, go to http://$HOST:4200/\\n"
     fi
 }
 
@@ -120,17 +119,22 @@ STABLE_RELEASE_URL=$(curl -Ls -I -w "%{url_effective}" \
 
 trap on_exit EXIT
 
-if [ ! -d "$STABLE_RELEASE_DIR" ]; then
-    prf "Hi and thank you for trying out CrateDB $STABLE_RELEASE_VERSION"
-    sleep 2
-    prf "\\n* Downloading CrateDB...\\n"
+prf "Thank you for trying out CrateDB $STABLE_RELEASE_VERSION\\n"
+
+if [ ! -f "$STABLE_RELEASE_FILENAME" ]; then
+    prf "* Downloading CrateDB"
     curl -L --max-redirs 1 -f ${STABLE_RELEASE_URL} > "$STABLE_RELEASE_FILENAME"
-    mkdir "$STABLE_RELEASE_DIR" && tar -xzf "$STABLE_RELEASE_FILENAME" -C "$STABLE_RELEASE_DIR" --strip-components 1
 else
-    prf "\\n* CrateDB $STABLE_RELEASE_VERSION has already been downloaded."
+    prf "- CrateDB $STABLE_RELEASE_VERSION has already been downloaded"
 fi
 
-prf "\\n* Starting CrateDB...\\n"
+if [ ! -d "$STABLE_RELEASE_DIR" ]; then
+    mkdir "$STABLE_RELEASE_DIR" && tar -xzf "$STABLE_RELEASE_FILENAME" -C "$STABLE_RELEASE_DIR" --strip-components 1
+else
+    prf "- Runtime directory $STABLE_RELEASE_DIR has already been created"
+fi
+
+prf "* Starting CrateDB"
 pre_start_cmd
 "$STABLE_RELEASE_DIR/bin/crate" &
 wait_until_running


### PR DESCRIPTION
Hi there,

in order to support users who like the quick installation program, like [1], this patch improves it on this matter. It will essentially allow installation on any flavor of Linux.

With kind regards,
Andreas.

[1] https://community.crate.io/t/installation-on-opensuse-fails/615
